### PR TITLE
expression: add like support (fix #99)

### DIFF
--- a/sql/expression/comparison_test.go
+++ b/sql/expression/comparison_test.go
@@ -12,6 +12,8 @@ const (
 	testEqual   = 1
 	testLess    = 2
 	testGreater = 3
+	testLike    = 4
+	testNotLike = 5
 )
 
 var comparisonCases = map[sql.Type]map[int][][]interface{}{
@@ -41,6 +43,33 @@ var comparisonCases = map[sql.Type]map[int][][]interface{}{
 		testGreater: {
 			{int32(2), int32(1)},
 			{int32(0), int32(-1)},
+		},
+	},
+}
+
+var likeComparisonCases = map[sql.Type]map[int][][]interface{}{
+	sql.String: {
+		testLike: {
+			{"foobar", "%bar"},
+			{"foobarfoo", "%bar%"},
+			{"bar", "bar"},
+			{"barfoo", "bar%"},
+		},
+		testNotLike: {
+			{"foobara", "%bar"},
+			{"foofoo", "%bar%"},
+			{"bara", "bar"},
+			{"abarfoo", "bar%"},
+		},
+	},
+	sql.Integer: {
+		testLike: {
+			{int32(1), int32(1)},
+			{int32(0), int32(0)},
+		},
+		testNotLike: {
+			{int32(-1), int32(0)},
+			{int32(1), int32(2)},
 		},
 	},
 }
@@ -114,6 +143,32 @@ func TestComparisons_GreaterThan(t *testing.T) {
 				cmp := eq.Eval(row)
 				assert.NotNil(cmp)
 				if cmpResult == testGreater {
+					assert.Equal(true, cmp)
+				} else {
+					assert.Equal(false, cmp)
+				}
+			}
+		}
+	}
+}
+
+func TestComparisons_Like(t *testing.T) {
+	assert := require.New(t)
+	for resultType, cmpCase := range likeComparisonCases {
+		get0 := NewGetField(0, resultType, "col1")
+		assert.NotNil(get0)
+		get1 := NewGetField(1, resultType, "col2")
+		assert.NotNil(get1)
+		eq := NewLike(get0, get1)
+		assert.NotNil(eq)
+		assert.Equal(sql.Boolean, eq.Type())
+		for cmpResult, cases := range cmpCase {
+			for _, pair := range cases {
+				row := sql.NewRow(pair[0], pair[1])
+				assert.NotNil(row)
+				cmp := eq.Eval(row)
+				assert.NotNil(cmp)
+				if cmpResult == testLike {
 					assert.Equal(true, cmp)
 				} else {
 					assert.Equal(false, cmp)

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -282,6 +282,8 @@ func comparisonExprToExpression(c *sqlparser.ComparisonExpr) (sql.Expression,
 	switch c.Operator {
 	default:
 		return nil, errUnsupportedFeature(c.Operator)
+	case sqlparser.LikeStr:
+		return expression.NewLike(left, right), nil
 	case sqlparser.EqualStr:
 		return expression.NewEquals(left, right), nil
 	case sqlparser.LessThanStr:


### PR DESCRIPTION
Added in a my-SQL way. If the type is not a string, the LIKE behavior is the same as Equals.