### PR TITLE
update to latest sqle.v0 api (NULL support)

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -25,8 +25,8 @@ func (blobsTable) Name() string {
 
 func (blobsTable) Schema() sql.Schema {
 	return sql.Schema{
-		sql.Column{"hash", sql.String},
-		sql.Column{"size", sql.BigInteger},
+		{Name: "hash", Type: sql.String, Nullable: false},
+		{Name: "size", Type: sql.BigInteger, Nullable: false},
 	}
 }
 

--- a/commits.go
+++ b/commits.go
@@ -25,14 +25,14 @@ func (commitsTable) Name() string {
 
 func (commitsTable) Schema() sql.Schema {
 	return sql.Schema{
-		sql.Column{"hash", sql.String},
-		sql.Column{"author_name", sql.String},
-		sql.Column{"author_email", sql.String},
-		sql.Column{"author_when", sql.TimestampWithTimezone},
-		sql.Column{"comitter_name", sql.String},
-		sql.Column{"comitter_email", sql.String},
-		sql.Column{"comitter_when", sql.TimestampWithTimezone},
-		sql.Column{"message", sql.String},
+		{Name: "hash", Type: sql.String, Nullable: false},
+		{Name: "author_name", Type: sql.String, Nullable: false},
+		{Name: "author_email", Type: sql.String, Nullable: false},
+		{Name: "author_when", Type: sql.TimestampWithTimezone, Nullable: false},
+		{Name: "comitter_name", Type: sql.String, Nullable: false},
+		{Name: "comitter_email", Type: sql.String, Nullable: false},
+		{Name: "comitter_when", Type: sql.TimestampWithTimezone, Nullable: false},
+		{Name: "message", Type: sql.String, Nullable: false},
 	}
 }
 

--- a/internal/format/pretty.go
+++ b/internal/format/pretty.go
@@ -26,6 +26,12 @@ func (pf *PrettyFormat) WriteHeader(headers []string) error {
 func (pf *PrettyFormat) Write(line []interface{}) error {
 	rowStrings := []string{}
 	for _, v := range line {
+		if tv, ok := v.(string); ok {
+			v = fmt.Sprintf(`"%s"`, tv)
+		} else if v == nil {
+			v = "NULL"
+		}
+
 		rowStrings = append(rowStrings, fmt.Sprintf("%v", v))
 	}
 	pf.tw.Append(rowStrings)

--- a/internal/format/pretty_test.go
+++ b/internal/format/pretty_test.go
@@ -9,14 +9,20 @@ func TestNewPrettyFormat(t *testing.T) {
 	w := bytes.NewBuffer(nil)
 	testFormat(&formatSpec{
 		Format: NewPrettyFormat(w),
-		Result: "+----+----+----+\n| A  | B  | C  |" +
-			"\n+----+----+----+\n| a1 | b1 | c1 |" +
-			"\n+----+----+----+\n",
+		Result: `` +
+			`+------+------+------+
+|  A   |  B   |  C   |
++------+------+------+
+| "a1" | "b1" | "c1" |
+| "a1" | "b1" | NULL |
+| "a1" | "b1" |    1 |
++------+------+------+
+`,
 		Headers: []string{"a", "b", "c"},
 		Lines: [][]interface{}{
-			[]interface{}{
-				"a1", "b1", "c1",
-			},
+			{"a1", "b1", "c1"},
+			{"a1", "b1", nil},
+			{"a1", "b1", 1},
 		},
 	}, w, t)
 }

--- a/objects.go
+++ b/objects.go
@@ -25,8 +25,8 @@ func (objectsTable) Name() string {
 
 func (objectsTable) Schema() sql.Schema {
 	return sql.Schema{
-		sql.Column{"id", sql.String},
-		sql.Column{"type", sql.String},
+		{Name: "id", Type: sql.String, Nullable: false},
+		{Name: "type", Type: sql.String, Nullable: false},
 	}
 }
 

--- a/references_test.go
+++ b/references_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"gopkg.in/sqle/sqle.v0/sql"
+	"gopkg.in/sqle/sqle.v0/sql/expression"
+	"gopkg.in/sqle/sqle.v0/sql/plan"
 
 	"github.com/src-d/go-git-fixtures"
 	"github.com/stretchr/testify/assert"
@@ -31,9 +33,21 @@ func TestReferencesTable_RowIter(t *testing.T) {
 	f := fixtures.Basic().One()
 	table := getTable(assert, f, referencesTableName)
 
-	rows, err := sql.NodeToRows(table)
+	rows, err := sql.NodeToRows(plan.NewSort(
+		[]plan.SortField{{Column: expression.NewGetField(0, sql.String, "name", false), Order: plan.Ascending}},
+		table))
 	assert.Nil(err)
-	assert.Len(rows, 7)
+
+	expected := []sql.Row{
+		sql.NewRow("HEAD", "symbolic-reference", nil, "refs/heads/master", false, false, false, false),
+		sql.NewRow("refs/heads/branch", "hash-reference", "e8d3ffab552895c19b9fcf7aa264d277cde33881", nil, true, false, false, false),
+		sql.NewRow("refs/heads/master", "hash-reference", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5", nil, true, false, false, false),
+		sql.NewRow("refs/remotes/origin/HEAD", "symbolic-reference", nil, "refs/remotes/origin/master", false, false, true, false),
+		sql.NewRow("refs/remotes/origin/branch", "hash-reference", "e8d3ffab552895c19b9fcf7aa264d277cde33881", nil, false, false, true, false),
+		sql.NewRow("refs/remotes/origin/master", "hash-reference", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5", nil, false, false, true, false),
+		sql.NewRow("refs/tags/v1.0.0", "hash-reference", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5", nil, false, false, false, true),
+	}
+	assert.Equal(expected, rows)
 
 	schema := table.Schema()
 	for idx, row := range rows {

--- a/tags.go
+++ b/tags.go
@@ -25,13 +25,13 @@ func (tagsTable) Name() string {
 
 func (tagsTable) Schema() sql.Schema {
 	return sql.Schema{
-		sql.Column{"hash", sql.String},
-		sql.Column{"name", sql.String},
-		sql.Column{"tagger_email", sql.String},
-		sql.Column{"tagger_name", sql.String},
-		sql.Column{"tagger_when", sql.TimestampWithTimezone},
-		sql.Column{"message", sql.String},
-		sql.Column{"target", sql.String},
+		{Name: "hash", Type: sql.String, Nullable: false},
+		{Name: "name", Type: sql.String, Nullable: false},
+		{Name: "tagger_email", Type: sql.String, Nullable: false},
+		{Name: "tagger_name", Type: sql.String, Nullable: false},
+		{Name: "tagger_when", Type: sql.TimestampWithTimezone, Nullable: false},
+		{Name: "message", Type: sql.String, Nullable: false},
+		{Name: "target", Type: sql.String, Nullable: false},
 	}
 }
 

--- a/tree_entries.go
+++ b/tree_entries.go
@@ -27,10 +27,10 @@ func (treeEntriesTable) Name() string {
 
 func (treeEntriesTable) Schema() sql.Schema {
 	return sql.Schema{
-		sql.Column{"tree_hash", sql.String},
-		sql.Column{"entry_hash", sql.String},
-		sql.Column{"mode", sql.String},
-		sql.Column{"name", sql.String},
+		{Name: "tree_hash", Type: sql.String, Nullable: false},
+		{Name: "entry_hash", Type: sql.String, Nullable: false},
+		{Name: "mode", Type: sql.String, Nullable: false},
+		{Name: "name", Type: sql.String, Nullable: false},
 	}
 }
 


### PR DESCRIPTION
* adapt to latest sqle.v0 api (NULL support)
* use NULL for target/hash in references table
* cmd: in pretty printing, print strings quoted
  to distinguish NULL and "NULL"

This PR depends on https://github.com/sqle/sqle/pull/25