### PR TITLE
Upgrade to latest go-git version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: false
 go:
-  - 1.7
   - 1.8
+  - 1.9
   - tip
 matrix:
   fast_finish: true

--- a/commits.go
+++ b/commits.go
@@ -58,7 +58,7 @@ func (commitsTable) Children() []sql.Node {
 }
 
 type commitIter struct {
-	i *object.CommitIter
+	i object.CommitIter
 }
 
 func (i *commitIter) Next() (sql.Row, error) {

--- a/database_test.go
+++ b/database_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/src-d/go-git-fixtures"
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/src-d/go-billy.v2/memfs"
+	"gopkg.in/src-d/go-billy.v3/memfs"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )


### PR DESCRIPTION
Do small changes to be able to use the last go-git v4 version.